### PR TITLE
Make frontend use gate output instead of hard-coded logic

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -35,9 +35,8 @@ return [
         ->listen(Saving::class, SaveNicknameToDatabase::class),
 
     (new Extend\ApiSerializer(UserSerializer::class))
-        ->attribute('canEditOwnNickname', function ($serializer, $user) {
-            $actor = $serializer->getActor();
-            return $actor->id === $user->id && $serializer->getActor()->can('editOwnNickname', $user);
+        ->attribute('canEditNickname', function (UserSerializer $serializer, User $user) {
+            return $serializer->getActor()->can('editNickname', $user);
         }),
 
     (new Extend\Settings())

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -11,12 +11,12 @@ import Stream from 'flarum/common/utils/Stream';
 import NickNameModal from './components/NicknameModal';
 
 app.initializers.add('flarum/nicknames', () => {
-  User.prototype.canEditOwnNickname = Model.attribute('canEditOwnNickname');
+  User.prototype.canEditNickname = Model.attribute('canEditNickname');
 
   extend(SettingsPage.prototype, 'accountItems', function (items) {
     if (app.forum.attribute('displayNameDriver') !== 'nickname') return;
 
-    if (this.user.canEditOwnNickname()) {
+    if (this.user.canEditNickname()) {
       items.add(
         'changeNickname',
         <Button className="Button" onclick={() => app.modal.show(NickNameModal)}>
@@ -27,13 +27,13 @@ app.initializers.add('flarum/nicknames', () => {
   });
 
   extend(EditUserModal.prototype, 'oninit', function () {
-    if (app.forum.attribute('displayNameDriver') !== 'nickname') return;
-
     this.nickname = Stream(this.attrs.user.displayName());
   });
 
   extend(EditUserModal.prototype, 'fields', function (items) {
     if (app.forum.attribute('displayNameDriver') !== 'nickname') return;
+
+    if (!this.attrs.user.canEditNickname()) return;
 
     items.add(
       'nickname',
@@ -52,7 +52,8 @@ app.initializers.add('flarum/nicknames', () => {
   extend(EditUserModal.prototype, 'data', function (data) {
     if (app.forum.attribute('displayNameDriver') !== 'nickname') return;
 
-    const user = this.attrs.user;
+    if (!this.attrs.user.canEditNickname()) return;
+
     if (this.nickname() !== this.attrs.user.displayName()) {
       data.nickname = this.nickname();
     }


### PR DESCRIPTION
**Changes proposed in this pull request:**
This PR removes any hard-coded logic that was used to show the edit nickname button and instead relies entirely on the gate output, so that custom policies affect the visibility of the button.

This new attribute is also used to show or hide the field in the edit user modal. Previously users without "Edit user attribute" permission but "Edit user credentials" permission would see the nickname field despite not being allowed to edit it.

**Reviewers should focus on:**
This drops an API attribute and model method. Should those be kept for backward-compatibility? The model attribute could be implemented client-side and just be the same as the new attribute + a check whether the user is the current session user.

I have dropped a condition from `EditUserModal.prototype.oninit` because this condition is duplicated across the 3 `extend()` calls but it's not really needed there. If I didn't remote it, I would have had to copy my new condition there as well to remove any confusion. By dropping the condition completely, there are only 2 methods where duplicated logic remains. I don't really think there's a way to de-duplicate that logic. I'm really not sure why the `if (app.forum.attribute('displayNameDriver') !== 'nickname') return;` condition exists. If you're not using Nicknames, this code would never be loaded anyway.

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
