### PR TITLE
fix: apply provided nickname in signup modal

### DIFF
--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -60,7 +60,7 @@ app.initializers.add('flarum/nicknames', () => {
   extend(SignUpModal.prototype, 'oninit', function () {
     if (app.forum.attribute('displayNameDriver') !== 'nickname') return;
 
-    this.nickname = Stream(this.attrs.username || '');
+    this.nickname = Stream(this.attrs.nickname || this.attrs.username || '');
   });
 
   extend(SignUpModal.prototype, 'onready', function () {


### PR DESCRIPTION
Related to https://github.com/flarum/nicknames/pull/8#issuecomment-2164460968

**Changes proposed in this pull request:**

**Scenario**: User logins with OAuth2, the OAuth server provides and numeric `id` and a string `nickname` such as "Robert Lan". This nickname is not valid as username in Flarum and will fail the regex validation. Hence I wish to set the user's name as nickname as it can't be a username.

**Purpose of change:** Today the Nickname signup modal doesn't respect code to provide nickname is username is also supplied.
```
Example from OAuth call
->provide('username', $user->getId())
->provide('nickname', $user->getName())
``` 
This ends up with both nickname and username fields just relecting the username. This is because of this line https://github.com/flarum/nicknames/blob/0821e5c982dd16d26c5260879b866eb416e8bb86/js/src/forum/index.js#L63 which only fetches a copy of the username in the nickname box. This is an issue because if you provide (instead of suggesting), the user should not be able to edit this field, though it's even more important that the provided value is displayed.

**What has changed**
I've just added a check for `attr.nickname` before it fallsback to `username` or blank.  This seems to solve the issue.

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
